### PR TITLE
Use pyflakes.api.isPythonFile to detect Python files

### DIFF
--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -1,4 +1,5 @@
 from pyflakes.checker import Binding, Assignment, Checker
+from pyflakes.api import isPythonFile
 import _ast
 import re
 import py
@@ -44,7 +45,7 @@ class FlakesPlugin(object):
 
     def pytest_collect_file(self, path, parent):
         config = parent.config
-        if config.option.flakes and path.ext == '.py':
+        if config.option.flakes and isPythonFile(path.strpath):
             flakes_ignore = self.ignore(path)
             if flakes_ignore is not None:
                 return FlakesItem(path, parent, flakes_ignore)

--- a/test_flakes.py
+++ b/test_flakes.py
@@ -48,3 +48,10 @@ def test_pep263(testdir):
     testdir.makepyfile(b'\n# encoding=utf-8\n\nsnowman = "\xe2\x98\x83"\n'.decode("utf-8"))
     result = testdir.runpytest("--flakes")
     assert '1 passed in' in result.stdout.str()
+
+
+def test_non_py_ext(testdir):
+    testdir.makefile('', '#!/usr/bin/env python', 'import sys')
+    result = testdir.runpytest('--flakes')
+    assert "UnusedImport\n'sys' imported but unused" in result.stdout.str()
+    assert 'passed' not in result.stdout.str()


### PR DESCRIPTION
This way, files that have a Python shebang but no .py extension are also
tested.

Fixes #16.