### PR TITLE
Use pycodestyle instead of pep8.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,11 +121,14 @@ and Holger Krekel's pytest-pep8.
 Changes
 =======
 
-3.0.3 - 2018-07-31
+4.0.0 - 2018-07-31
 ------------------
 
+- Use pytest-codestyle instead of pytest-pep8. pep8 was renamed and is
+  maintained as pycodestyle. [smarlowucf]
 - Update pytest-cache requirement. Cache is included in pytest >= 2.8.0.
   [smarlowucf]
+- Remove executable bit from LICENSE file. [smarlowucf]
 
 3.0.2 - 2018-05-16
 ------------------

--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -13,6 +13,7 @@ def assignment_monkeypatched_init(self, name, source):
     if name == '__tracebackhide__':
         self.used = True
 
+
 Assignment.__init__ = assignment_monkeypatched_init
 
 
@@ -97,7 +98,7 @@ class FlakesItem(pytest.Item, pytest.File):
 
 
 class Ignorer:
-    def __init__(self, ignorelines, coderex=re.compile("[EW]\d\d\d")):
+    def __init__(self, ignorelines, coderex=re.compile(r"[EW]\d\d\d")):
         self.ignores = ignores = []
         for line in ignorelines:
             i = line.find("#")
@@ -115,13 +116,13 @@ class Ignorer:
             ignores.append((glob, ign))
 
     def __call__(self, path):
-        l = set()
+        ignored = set()
         for (glob, ignlist) in self.ignores:
             if not glob or path.fnmatch(glob):
                 if ignlist is None:
                     return None
-                l.update(set(ignlist))
-        return sorted(l)
+                ignored.update(set(ignlist))
+        return sorted(ignored)
 
 
 def check_file(path, flakesignore):

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setup(
     ],
     py_modules=['pytest_flakes'],
     entry_points={'pytest11': ['flakes = pytest_flakes']},
-    install_requires=['pytest>=2.8.0', 'pyflakes'])
+    install_requires=['pytest>=2.8.0', 'pyflakes'],
+    extras_require={
+        'tests': ['coverage', 'pytest-codestyle']
+    })

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py34,py35,py36
 usedevelop = true
 deps =
     pytest
-    pytest-pep8
+    pytest-codestyle
     coverage
 commands =
     coverage erase
@@ -14,6 +14,6 @@ commands =
     coverage html -d htmlcov-{envname}
 
 [pytest]
-addopts = --flakes --pep8
-pep8ignore = E501
+addopts = --flakes --codestyle
+codestyle_ignore = E501
 norecursedirs = bin lib include Scripts .*


### PR DESCRIPTION
- pep8 was renamed and pycodestyle is the maintained package.
- Update readme changelog for 4.0.0.