### PR TITLE
Prepare for upcoming pytest 7.0 deprecations (part 2)

### DIFF
--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -47,13 +47,13 @@ class FlakesPlugin:
         self.mtimes = config.cache.get(HISTKEY, {})
 
     if PYTEST_GTE_7:
-        def pytest_collect_file(self, fspath, parent):
+        def pytest_collect_file(self, file_path, parent):
             config = parent.config
-            if config.option.flakes and isPythonFile(str(fspath)):
-                flakesignore = self.ignore(fspath)
+            if config.option.flakes and isPythonFile(str(file_path)):
+                flakesignore = self.ignore(file_path)
                 if flakesignore is not None:
                     return FlakesFile.from_parent(parent,
-                                                  path=fspath,
+                                                  path=file_path,
                                                   flakesignore=flakesignore)
     else:
         def pytest_collect_file(self, path, parent):


### PR DESCRIPTION
This follows up #42, we decided that using just `fspath` as the new
parameter that users should use would be confusing because it is too
close to `path` and also we have `fspath` already in some places of
the pytest public API (see pytest-dev/pytest#9283).

This PR updates the hook affected by this new change in pytest-dev/pytest#9363.