### PR TITLE
Fix glob matching

### DIFF
--- a/pytest_flakes.py
+++ b/pytest_flakes.py
@@ -6,6 +6,7 @@ import pathlib
 import pytest
 import sys
 import tokenize
+import fnmatch
 
 
 PYTEST_GTE_7 = hasattr(pytest, 'version_tuple') and pytest.version_tuple >= (7, 0)
@@ -148,7 +149,7 @@ class Ignorer:
     def __call__(self, path):
         l = set()
         for (glob, ignlist) in self.ignores:
-            if not glob or path.glob(glob):
+            if not glob or fnmatch.fnmatch(path, glob):
                 if ignlist is None:
                     return None
                 l.update(set(ignlist))


### PR DESCRIPTION
Hi!
I had this issue today, I suggest a fix. I hope it helps.

The output of `pathlib.Path.glob` is a generator. So it was always evaluating to true.